### PR TITLE
Increased file size limit to 50 GB (due to zStacks being large)

### DIFF
--- a/exact/exact/base/static/jQuery-File-Upload/js/main.js
+++ b/exact/exact/base/static/jQuery-File-Upload/js/main.js
@@ -19,7 +19,7 @@ $(function () {
         // Uncomment the following to send cross-domain cookies:
         //xhrFields: {withCredentials: true},
         sequentialUploads: true, // solves the issues with high Image counts... hopefully.
-        maxFileSize: 10000000000
+        maxFileSize: 50000000000
     });
 
     // Enable iframe cross-domain access via redirect option:


### PR DESCRIPTION
The zStack project requires file uploads to be greater than 10GB, hence we increase it to 50GB.