### PR TITLE
Fixed qt-wsi-registration version

### DIFF
--- a/exact/requirements.txt
+++ b/exact/requirements.txt
@@ -39,8 +39,9 @@ czifile==2019.7.2
 gitpython==3.1.11
 gdown==5.1.0
 pandas==2.2.1
-qt-wsi-registration==0.0.11
+qt-wsi-registration==0.0.12
 EXCAT-Sync>=0.0.38
 pyyaml>=6.0.1
 aicsimageio==4.11.0
+Werkzeug==2.3.7
 h5py==3.10.0


### PR DESCRIPTION
Updated the qt-wsi-registration to the latest version 0.0.12. The latest version fixed the probreg version to 0.3.5. See https://github.com/ChristianMarzahl/WsiRegistration/commit/525ae4cda15768af1de7cf0663b9d436a410de43.