### PR TITLE
Read pyramidal .ome.tif slides

### DIFF
--- a/exact/requirements.txt
+++ b/exact/requirements.txt
@@ -32,6 +32,7 @@ gunicorn==21.2.0
 opencv-python>=4.9.0.80
 openslide-python==1.3.1
 tifffile==2023.2.28
+ome-types>=0.5.1
 pyvips>=2.2.1
 pydicom>=2.4.4
 ptvsd>=4.3.2


### PR DESCRIPTION
Openslide currently does not support ome-tif files. This provides a simple class to read ome-tif files as zarr-arrays. We assume that pyramidal levels are stored as a single series to the file. The class provides a similar interface to the images as openslide for simple integration with the other formats. For the support of multi-z-stack ome-tif files, we can combine multiple OMETiffSlides together. This is supported by the OMETiffZStack class. Here we assume that the zstacks are stored as multiple series each having its own pyramid. 