### PR TITLE
Bump zarr to ver 2.18.6 to fix issue with numcodecs 0.16.0

### DIFF
--- a/exact/requirements.txt
+++ b/exact/requirements.txt
@@ -20,7 +20,7 @@ django-widget-tweaks==1.5.0
 djangorestframework==3.15.2
 djangorestframework-simplejwt==5.3.1
 djoser==2.3.0
-zarr==2.15.0
+zarr==2.18.7
 xmltodict==0.13.0
 uritemplate==4.1.1
 fasteners==0.15


### PR DESCRIPTION
Hi, 

latest version of `numcodecs` breaks compatibility with `zarr<3` (see e.g., https://github.com/zarr-developers/zarr-python/issues/2963) which leads to import errors for the web server of Exact. This has been addressed in `zarr=2.18.6` by pinning an older version of numcodecs. 

This PR pins zarr to the fixed version. 

Best,
Jonas 